### PR TITLE
Fixes #1, Export files larger than 4GB correctly

### DIFF
--- a/src/xt-gexpo.c
+++ b/src/xt-gexpo.c
@@ -1098,7 +1098,7 @@ XT_Finalize (HANDLE hVolume, HANDLE hEvidence, DWORD nOpType, PVOID lpReserved)
             // declare all variables we need for reading the current file...
             INT64 i64DataSizeRead = 0;       //amount of data of the current file that has already been processed
             INT64 i64DataSizeToRead = 0;     //determines how much data to read in this iteration
-            HANDLE file = MyCreateFile(filepath);
+            HANDLE file = NULL;
             DWORD actual_size = 0;
 
             // Start of loop for exporting files...
@@ -1156,6 +1156,10 @@ XT_Finalize (HANDLE hVolume, HANDLE hEvidence, DWORD nOpType, PVOID lpReserved)
                 }
                 else
                 {
+                    // Create file on first iteration, but only when we are actually going to export data
+                    if (NULL == file) {
+                        file = MyCreateFile(filepath);
+                    }
                     if (INVALID_HANDLE_VALUE == file)
                     {
                         XWF_Close(hItem);

--- a/src/xt-gexpo.c
+++ b/src/xt-gexpo.c
@@ -1152,7 +1152,6 @@ XT_Finalize (HANDLE hVolume, HANDLE hEvidence, DWORD nOpType, PVOID lpReserved)
                     // reference does not contain any actual data.
                     free(filebuf);
                     current_volume->report->empty_count++;
-                    XWF_Close(hItem);
                 }
                 else
                 {
@@ -1178,6 +1177,7 @@ XT_Finalize (HANDLE hVolume, HANDLE hEvidence, DWORD nOpType, PVOID lpReserved)
                     if (FALSE == rv)
                     {
                         CloseHandle(file);
+                        XWF_Close(hItem);
                         XWF_OutputMessage(L"ERROR: Griffeye XML export X-Ten"
                                           "sion could not write to export d"
                                           "irectory. Aborting.", 0);
@@ -1190,6 +1190,7 @@ XT_Finalize (HANDLE hVolume, HANDLE hEvidence, DWORD nOpType, PVOID lpReserved)
             } //while loop exporting file
 
             CloseHandle(file);
+            XWF_Close(hItem);
 
             XWF_AddToReportTable(file_ids[i].xwf_id, REP_TABLE_SUCCESS, 1);
 


### PR DESCRIPTION
A PR implementing the changes suggested by @k5coder to fix #1 with minimal changes:

- Removed check if `actual_size` is small than `expected_size`. This check doesn't make sense anymore, since we are exporting the file in multiple steps and `actual_size` only represents the size of one iteration. If this check isn't removed, we get wrong file sizes in the XML file. This also eliminates the need for the `[XT][gexpo] exported (size mismatch)` report table.
- Removed `i64FileChunk` and `i64_2GB` and replaced them with a preprocessor macro.